### PR TITLE
added "maxResults" parameter

### DIFF
--- a/css/Geocoder.css
+++ b/css/Geocoder.css
@@ -364,6 +364,8 @@
 }
 
 .simpleGeocoder .esriGeocoderResults {
+    max-height: 140px;
+    overflow: auto;
     display: none;
     z-index: 99;
     width: 100%;

--- a/js/Geocoder.js
+++ b/js/Geocoder.js
@@ -92,6 +92,7 @@ function (
                 geocoderMenu: true, // Show geocoder menu if necessary
                 autoNavigate: true, // Automatically navigate
                 showResults: true, // show result suggestions
+                maxResults: 5, // maximum number of results that will return in the GeocoderResults window.
                 map: null,
                 activeGeocoder: null,
                 geocoders: null,
@@ -114,6 +115,7 @@ function (
             this.set("geocoderMenu", defaults.geocoderMenu);
             this.set("autoNavigate", defaults.autoNavigate);
             this.set("showResults", defaults.showResults);
+            this.set("maxResults", defaults.maxResults);
             this.set("map", defaults.map);
             this.set("activeGeocoder", defaults.activeGeocoder);
             this.set("geocoders", defaults.geocoders);
@@ -222,7 +224,7 @@ function (
                     gl.remove(g);
                 }
                 else{
-                    this.get("map").graphics.remove(g);   
+                    this.get("map").graphics.remove(g);
                 }
                 this.set("highlightGraphic", null);
             }
@@ -553,7 +555,7 @@ function (
             }
             else{
                 // create locator task
-                this._task = new Locator(this.get("activeGeocoder").url);    
+                this._task = new Locator(this.get("activeGeocoder").url);
             }
             // update placeholder nodes
             this._updatePlaceholder();
@@ -707,7 +709,7 @@ function (
                 if(this.get("activeGeocoder").type === 'query'){
                     var q = new Query();
                     // spatial ref
-                    q.outSpatialReference = outSpatialReference; 
+                    q.outSpatialReference = outSpatialReference;
                     q.returnGeometry = true;
                     q.num = num;
                     if(searchExtent){
@@ -828,7 +830,7 @@ function (
                 var r = new RegExp('(' + partialMatch + ')', 'gi');
                 html += '<ul role="presentation">';
                 // for each result
-                for (i = 0; i < this.get("results").length && i < 5; ++i) {
+                for (i = 0; i < this.get("results").length && i < this.maxResults; ++i) {
                     // location text
                     var text = this.get("results")[i].text || this.get("results")[i].name;
                     // set layer class
@@ -894,7 +896,7 @@ function (
         },
         // show geocoder selection menu
         _showGeolocatorMenu: function () {
-            // add class to container                
+            // add class to container
             domClass.add(this.containerNode, this._css.activeMenuClass);
             domClass.add(this.domNode, this._css.GeocoderMenuOpenClass);
             // display menu node
@@ -1075,7 +1077,7 @@ function (
                 var newVal = this.inputNode.value.slice(0,-1);
                 domAttr.set(this.inputNode, 'value', newVal);
                 this.set("value", newVal);
-              }  
+              }
               else if (e.type === 'keydown' && e.keyCode === keys.UP_ARROW) {
                     event.stop(e);
                     // go to previous item
@@ -1327,7 +1329,7 @@ function (
             //disable navigation (so keyboard arrows stop panning map)
             var map = this.get("map");
             if(map){
-                map.disableKeyboardNavigation();   
+                map.disableKeyboardNavigation();
             }
         },
         _hydrateResult: function (e) {
@@ -1433,7 +1435,7 @@ function (
                         });
                     }
                     break;
-                }  
+                }
             } else {
                 newResult.extent = null;
             }


### PR DESCRIPTION
added a new parameter, "maxResults", that allows the number of results
added to the resultsNode to be set, instead of the static 5 results.

Height of the container is kept to 5 lines, but overflow is set to auto
to allow scrolling thru the results.